### PR TITLE
Fix nonconforming issue templates [Hotfix]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.yml
@@ -3,7 +3,7 @@ description: File a bug report
 title: '[Bug]: '
 labels:
   - bug
-assignees: null
+assignees: []
 body:
   - type: markdown
     attributes:
@@ -33,8 +33,8 @@ body:
       description: >-
         Please link the pull request or commit corresponding to the behaviour
         described in the bug report.
-      validations:
-        required: false
+    validations:
+      required: false
   - type: textarea
     id: environment
     attributes:
@@ -42,14 +42,14 @@ body:
       description: >-
         Describe the environment(s) in which the bug occurs, including both
         build and runtime environments, where relevant.
-      validations:
-        required: false
+    validations:
+      required: false
   - type: textarea
     id: reproduce
     attributes:
       label: Steps to Reproduce
       description: >
-        1. Go to '...' 
+        1. Go to '...'
 
         2. Tap on '....'
 
@@ -61,22 +61,22 @@ body:
         If applicable, add screenshots to help explain your problem. All
         screenshots must be resized so that they display at a comfortable size
         for viewing.
-      validations:
-        required: false
+    validations:
+      required: false
   - type: textarea
     id: expected
     attributes:
       label: Expected Behaviour
       description: A clear and concise description of what you expected to happen.
-      validations:
-        required: false
+    validations:
+      required: false
   - type: textarea
     id: extra
     attributes:
       label: Additional Information
       description: Any additional information about the problem that might be relevant.
-      validations:
-        required: false
+    validations:
+      required: false
   - type: textarea
     id: solution
     attributes:
@@ -86,5 +86,5 @@ body:
         and suggest directions for future investigation in the absence of
         obvious solutions. Discuss any partial solutions or unsuccessful
         approaches that have been tested so far.
-      validations:
-        required: false
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request_template.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.yml
@@ -3,7 +3,7 @@ description: Submit a proposal for a new feature
 title: '[Feature]: '
 labels:
   - feature
-assignees: null
+assignees: []
 body:
   - type: markdown
     attributes:
@@ -29,9 +29,9 @@ body:
     attributes:
       label: Feature Description
       description: >-
-        A description of what you would like to happen. 
-        Be as descriptive as possible to give a clear idea of the feature. 
-        Describe what would be in the scope of the feature and out of the scope of the feature. 
+        A description of what you would like to happen.
+        Be as descriptive as possible to give a clear idea of the feature.
+        Describe what would be in the scope of the feature and out of the scope of the feature.
         Explanatory mockups or sketches are also welcome.
     validations:
       required: true


### PR DESCRIPTION
I'd like to merge my hotfix branch into the development branch.

This pull request is related to the following task IDs on ProofHub: None

## Summary of changes

I updated the issue templates to fix GitHub template validation errors.

## Any tips to help running or testing the new changes

View each template on GitHub under `.github/ISSUE_TEMPLATE/`. You should see that GitHub renders it as a form, not a YAML file, indicating that the template is valid.

## Notes

Thanks for reviewing and helping the team to improve quality of their work with your feedback.
