### PR TITLE
Custom UI Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ You can you can set the flag `isCustomUI` to true and use the exposed functions 
 
 If you are using a custom user interface you cannot currently add metadata to the shapes and will have to handle that externally.
 
+There is an example app that shows basic use of a custom user interface in `CustomUIApp.tsx`. In order to use this app follow the instructions for running the default [example](#example) app but rename `CustomUIApp.tsx` to `App.tsx`.
+
 In the future, either `<GeometryEditorUI/>` should accept more user interface customization options, or `<GeometryEditor/>` may expose a more full programmatic interface for editing geometry.
 Otherwise, it will continue to be difficult to adapt geometry editing controls to the look and feel of the surrounding app.
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,33 @@
 <!-- omit in toc -->
+
 # react-native-mapbox-geometry-editor
 
 Interactive shape editing on top of the Mapbox Maps SDK for React Native
 
 <!-- omit in toc -->
+
 ## Table of Contents
-- [Example](#example)
-- [Features](#features)
-  - [Limitations](#limitations)
-- [Installation](#installation)
-  - [Import options](#import-options)
-- [Usage](#usage)
-  - [Geometry format and metadata](#geometry-format-and-metadata)
-    - [Advanced usage](#advanced-usage)
-- [API Documentation](#api-documentation)
-- [Utility scripts](#utility-scripts)
-- [Known issues and future work](#known-issues-and-future-work)
+
+- [react-native-mapbox-geometry-editor](#react-native-mapbox-geometry-editor)
+  - [Table of Contents](#table-of-contents)
+  - [Example](#example)
+  - [Features](#features)
+    - [Limitations](#limitations)
+  - [Installation](#installation)
+    - [Import options](#import-options)
+  - [Usage](#usage)
+    - [Geometry format and metadata](#geometry-format-and-metadata)
+      - [Advanced usage](#advanced-usage)
   - [Custom user interface](#custom-user-interface)
-  - [Packaging and publishing](#packaging-and-publishing)
-  - [Minor general issues](#minor-general-issues)
-  - [Android-specific issues](#android-specific-issues)
-  - [iOS-specific issues](#ios-specific-issues)
-- [Contributing](#contributing)
-- [License](#license)
+  - [API Documentation](#api-documentation)
+  - [Utility scripts](#utility-scripts)
+  - [Known issues and future work](#known-issues-and-future-work)
+    - [Packaging and publishing](#packaging-and-publishing)
+    - [Minor general issues](#minor-general-issues)
+    - [Android-specific issues](#android-specific-issues)
+    - [iOS-specific issues](#ios-specific-issues)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Example
 
@@ -75,6 +80,7 @@ Refer to the [Mapbox Maps SDK for React Native's documentation](https://github.c
 ### Import options
 
 The library provides build targets to suit different transpilation mechanisms:
+
 - Commonjs module system: `lib/commonjs`
 - ES6 module system (useful for tree-shaking): `lib/module`
 - TypeScript: `lib/typescript`
@@ -107,6 +113,7 @@ Note that schema descriptions are requested immediately before an interface is o
 If a schema description returned by a function is not `null`, it must be an object of the form parsed by [`@demvsystems/yup-ast`](https://github.com/demvsystems/yup-ast), subject to restrictions described below.
 
 The schema description must contain a top-level object:
+
 ```TypeScript
 [
   ['yup.object'],
@@ -123,6 +130,7 @@ The schema description must contain a top-level object:
 
 The `FIELDS` portion contains the actual fields of the GeoJSON metadata.
 The datatype of a field must be one of the following:
+
 - `fieldKey: [['yup.mixed'], ['yup.oneOf', ["ARRAY", "OF", "STRINGS" ]],]`: A string-typed enumeration, where the array of possible values must have at least one element
 - `fieldKey: [['yup.string']]`: A string
 - `fieldKey: [['yup.number']]`: A number
@@ -133,6 +141,7 @@ The library will only display and allow editing of fields of the supported types
 The library will also ignore all properties of metadata objects that are not described in the schema.
 
 The schema description can (and should) contain human-readable text to assist the user:
+
 - Fields can be given human-readable names using the `'yup.label'` attribute.
   For example, `fieldKey: [['yup.boolean'], ['yup.label', 'Field name'],]` gives the field a name of `'Field name'`.
   If a label is not provided, the field name will default to the field's key.
@@ -168,6 +177,20 @@ Object-level meta information is described by the `MetadataAttributes` interface
 Please read the code documentation comments of these interfaces for descriptions of the available options.
 Default values for meta information are provided by the `metadataAttributesImpl` and `fieldAttributesImpl` validators in `src/util/metadata/schema.ts`, so the client application only needs to provide any meta information properties whose values must differ from the defaults.
 
+## Custom user interface
+
+The `<GeometryEditorUI/>` component renders a graphical user interface for editing geometry on top of a map.
+(It also renders the map.)
+The user interface is not customizable aside from some coarse style settings.
+
+The library also exposes a `<GeometryEditor/>` component that renders a map, but no geometry editing controls.
+You can you can set the flag `isCustomUI` to true and use the exposed functions to create your own custom user interface while using this component. Most of the necessary functions are available as part of `ref`. There are also some variables that you may wish to access in order to know when certain buttons should be active or displayed, in order to access these you must pass a setter function as a prop so that the `<GeometryEditor/>` can set the value for you to use.
+
+If you are using a custom user interface you cannot currently add metadata to the shapes and will have to handle that externally.
+
+In the future, either `<GeometryEditorUI/>` should accept more user interface customization options, or `<GeometryEditor/>` may expose a more full programmatic interface for editing geometry.
+Otherwise, it will continue to be difficult to adapt geometry editing controls to the look and feel of the surrounding app.
+
 ## API Documentation
 
 HTML API documentation for the library can be generated using Typedoc as follows:
@@ -181,18 +204,6 @@ HTML API documentation for the library can be generated using Typedoc as follows
 - [`fix_winding.js`](./tool/fix_winding.js): A script that corrects the winding order of GeoJSON polygons in GeoJSON data. This script is helpful when preparing data to be imported into the geometry editing library.
 
 ## Known issues and future work
-
-### Custom user interface
-
-The `<GeometryEditorUI/>` component renders a graphical user interface for editing geometry on top of a map.
-(It also renders the map.)
-The user interface is not customizable aside from some coarse style settings.
-
-The library also exposes a `<GeometryEditor/>` component that renders a map, but no geometry editing controls.
-As a result, this component can only be used to display geometry.
-
-In the future, either `<GeometryEditorUI/>` should accept more user interface customization options, or `<GeometryEditor/>` should expose a full programmatic interface for editing geometry.
-Otherwise, it will continue to be difficult to adapt geometry editing controls to the look and feel of the surrounding app.
 
 ### Packaging and publishing
 
@@ -214,10 +225,12 @@ In the future, this library should be published to a package repository, such as
   The library is still able to handle enumeration and boolean-typed fields that have missing or invalid values, however, such as when rendering metadata created outside the library.
 
 ### Android-specific issues
+
 - Geometry rendering on an Android emulator may exhibit visual problems such as rendering points in grey instead of in their desired colours.
   Zooming in and out on the map may make colours randomly appear and disappear.
 
 ### iOS-specific issues
+
 - To drag an editable point, it may be necessary to first tap on the point (press and release) before pressing and holding to drag the point.
 - Editable points may snap back to their original positions while or after being dragged (https://github.com/rnmapbox/maps/issues/1117).
 - To draw a new point, it may be necessary to first tap on the map, to switch focus to the map, after having tapped on a geometry object or on a user interface element.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ You can you can set the flag `isCustomUI` to true and use the exposed functions 
 
 If you are using a custom user interface you cannot currently add metadata to the shapes and will have to handle that externally.
 
-There is an example app that shows basic use of a custom user interface in `CustomUIApp.tsx`. In order to use this app follow the instructions for running the default [example](#example) app but rename `CustomUIApp.tsx` to `App.tsx`.
+There is an example app that shows basic use of a custom user interface that can be accessed by pressing the `Toggle UI` button in the example app.
 
 In the future, either `<GeometryEditorUI/>` should accept more user interface customization options, or `<GeometryEditor/>` may expose a more full programmatic interface for editing geometry.
 Otherwise, it will continue to be difficult to adapt geometry editing controls to the look and feel of the surrounding app.

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -64,6 +64,7 @@ import type {
   SemanticGeometryType,
   StyleGeneratorMap,
 } from 'react-native-mapbox-geometry-editor';
+import { CustomUIApp } from './CustomUIApp';
 
 const styles = StyleSheet.create({
   container: {
@@ -85,6 +86,18 @@ const styles = StyleSheet.create({
   ioControlsContainer: {
     position: 'relative',
     alignSelf: 'flex-end',
+  },
+  buttonContainer: { flexDirection: 'row', justifyContent: 'space-between' },
+  toggleContainer: {
+    position: 'relative',
+    alignSelf: 'flex-start',
+  },
+  toggleButton: {
+    marginTop: 10,
+    marginBottom: 5,
+    marginLeft: 10,
+    padding: 3,
+    borderRadius: 10,
   },
   importButton: {
     marginTop: 10,
@@ -495,6 +508,7 @@ function IOControls({
   onImport,
   onExport,
   disabled,
+  setCustomUI,
 }: {
   /**
    * Import button press event handler
@@ -508,27 +522,42 @@ function IOControls({
    * Whether or not the buttons should be disabled
    */
   disabled: boolean;
+  /**
+   * Set whether or not to display a custom UI or the default UI
+   */
+  setCustomUI: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   let buttonColor = 'orange';
+  let toggleButtonColor = 'orange';
   if (disabled) {
     buttonColor = 'grey';
   }
   return (
-    <View style={styles.ioControlsContainer}>
-      <Pressable
-        style={[styles.importButton, { backgroundColor: buttonColor }]}
-        onPress={onImport}
-        disabled={disabled}
-      >
-        <Text style={styles.text}>Import static shapes</Text>
-      </Pressable>
-      <Pressable
-        style={[styles.exportButton, { backgroundColor: buttonColor }]}
-        onPress={onExport}
-        disabled={disabled}
-      >
-        <Text style={styles.text}>Export shapes</Text>
-      </Pressable>
+    <View style={styles.buttonContainer}>
+      <View style={styles.toggleContainer}>
+        <Pressable
+          style={[styles.toggleButton, { backgroundColor: toggleButtonColor }]}
+          onPress={() => setCustomUI((prevValue) => !prevValue)}
+        >
+          <Text style={styles.text}>Toggle UI</Text>
+        </Pressable>
+      </View>
+      <View style={styles.ioControlsContainer}>
+        <Pressable
+          style={[styles.importButton, { backgroundColor: buttonColor }]}
+          onPress={onImport}
+          disabled={disabled}
+        >
+          <Text style={styles.text}>Import static shapes</Text>
+        </Pressable>
+        <Pressable
+          style={[styles.exportButton, { backgroundColor: buttonColor }]}
+          onPress={onExport}
+          disabled={disabled}
+        >
+          <Text style={styles.text}>Export shapes</Text>
+        </Pressable>
+      </View>
     </View>
   );
 }
@@ -642,34 +671,43 @@ export default function App() {
    * geometry editing operation
    */
   const [disableIO, setDisableIO] = useState(false);
+  const [customUI, setCustomUI] = useState(false);
   const interactionHandlers: InteractionEventProps = useMemo(() => {
     return {
       onEditingStatus: setDisableIO,
     };
   }, [setDisableIO]);
 
-  return (
-    <SafeAreaView style={styles.container}>
-      <IOControls disabled={disableIO} {...ioHandlers} />
-      <GeometryEditorUI
-        cameraControls={cameraControls}
-        style={styles.libraryContainer}
-        theme={DarkTheme}
-        mapProps={{
-          style: styles.map,
-          styleURL: 'mapbox://styles/mapbox/dark-v10',
-        }}
-        metadataSchemaGeneratorMap={metadataSchemaGeneratorMap}
-        styleGenerators={styleGeneratorMap}
-        interactionEventProps={interactionHandlers}
-        ref={ioRef}
-      >
-        <MapboxGL.Camera
-          ref={cameraRef}
-          centerCoordinate={[3.380271, 6.464217]}
-          zoomLevel={14}
+  if (customUI) {
+    return <CustomUIApp setCustomUI={setCustomUI} />;
+  } else {
+    return (
+      <SafeAreaView style={styles.container}>
+        <IOControls
+          disabled={disableIO}
+          setCustomUI={setCustomUI}
+          {...ioHandlers}
         />
-      </GeometryEditorUI>
-    </SafeAreaView>
-  );
+        <GeometryEditorUI
+          cameraControls={cameraControls}
+          style={styles.libraryContainer}
+          theme={DarkTheme}
+          mapProps={{
+            style: styles.map,
+            styleURL: 'mapbox://styles/mapbox/dark-v10',
+          }}
+          metadataSchemaGeneratorMap={metadataSchemaGeneratorMap}
+          styleGenerators={styleGeneratorMap}
+          interactionEventProps={interactionHandlers}
+          ref={ioRef}
+        >
+          <MapboxGL.Camera
+            ref={cameraRef}
+            centerCoordinate={[3.380271, 6.464217]}
+            zoomLevel={14}
+          />
+        </GeometryEditorUI>
+      </SafeAreaView>
+    );
+  }
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -38,6 +38,7 @@ if (!getTimeMilliseconds) {
  */
 LogBox.ignoreLogs([
   "[mobx] Derivation 'observer_StoreProvider' is created/updated without reading any observable value.",
+  "[mobx] Derivation 'observerobserved' is created/updated without reading any observable value.",
 ]);
 
 /**

--- a/example/src/CustomUIApp.tsx
+++ b/example/src/CustomUIApp.tsx
@@ -21,6 +21,7 @@ import token from '../mapbox_token.json';
  */
 LogBox.ignoreLogs([
   "[mobx] Derivation 'observer_StoreProvider' is created/updated without reading any observable value.",
+  "[mobx] Derivation 'observerobserved' is created/updated without reading any observable value.",
 ]);
 
 /**

--- a/example/src/CustomUIApp.tsx
+++ b/example/src/CustomUIApp.tsx
@@ -4,7 +4,6 @@
 
 import { useMemo, useRef, useState } from 'react';
 import {
-  Alert,
   LogBox,
   SafeAreaView,
   StyleSheet,
@@ -16,21 +15,6 @@ import {
 import MapboxGL from '@rnmapbox/maps';
 
 import token from '../mapbox_token.json';
-import sampleFeatures from './sample.json';
-import type { FeatureCollection } from 'geojson';
-
-/**
- * A way to get the `performance.now()` interface, for timing code,
- * in both debug and release mode
- * See https://github.com/MaxGraey/react-native-console-time-polyfill/blob/master/index.js
- */
-const getTimeMilliseconds =
-  ((global as any).performance && (global as any).performance.now) ||
-  (global as any).performanceNow ||
-  (global as any).nativePerformanceNow;
-if (!getTimeMilliseconds) {
-  throw new Error('Failed to find performance.now() or an equivalent.');
-}
 
 /**
  * Hide known issue in the library (refer to the README)
@@ -44,20 +28,10 @@ LogBox.ignoreLogs([
  * See https://github.com/uuidjs/uuid#getrandomvalues-not-supported
  */
 import 'react-native-get-random-values';
-import {
-  defaultStyleGeneratorMap,
-  FeatureLifecycleStage,
-  featureLifecycleStageColor,
-  CoordinateRole,
-  validateMetadata,
-  GeometryEditor,
-} from 'react-native-mapbox-geometry-editor';
+import { GeometryEditor } from 'react-native-mapbox-geometry-editor';
 import type {
   CameraControls,
-  DraggablePointStyle,
-  EditableFeature,
   GeometryIORef,
-  StyleGeneratorMap,
 } from 'react-native-mapbox-geometry-editor';
 
 const styles = StyleSheet.create({
@@ -79,6 +53,7 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     flexDirection: 'row',
   },
+  buttonContainer: { flexDirection: 'row', justifyContent: 'space-between' },
   button: {
     marginBottom: 5,
     marginRight: 10,
@@ -97,290 +72,6 @@ const styles = StyleSheet.create({
 MapboxGL.setAccessToken(token.accessToken);
 
 /**
- * Example enumeration used for an option select
- * geometry metadata field
- *
- * Also used for data-driven geometry styling
- */
-enum VehicleType {
-  Car = 'CAR',
-  Train = 'TRAIN',
-  Boat = 'BOAT',
-  Bicycle = 'BICYCLE',
-}
-
-/**
- * Default colours for vehicle types
- * @param stage The vehicle type
- * @return A specific or a default colour, depending on whether `type` is defined
- */
-function vehicleTypeColor(type?: VehicleType): string {
-  switch (type) {
-    case VehicleType.Car:
-      return '#ff1493'; // Deep pink
-    case VehicleType.Train:
-      return '#adff2f'; // Green yellow
-    case VehicleType.Boat:
-      return '#0000cd'; // Medium blue
-    case VehicleType.Bicycle:
-      return '#f4a460'; // Sandy brown
-    default:
-      return '#ffffff'; // White
-  }
-}
-
-/**
- * Enumeration for data-driven styling of polygons
- */
-enum ZoneType {
-  Parking = 'PARKING',
-  Restricted = 'RESTRICTED',
-}
-
-/**
- * Default colours for {@link ZoneType} types
- * @param stage The zone type
- * @return A specific or a default colour, depending on whether `type` is defined
- */
-function zoneTypeColor(type?: ZoneType): string {
-  switch (type) {
-    case ZoneType.Parking:
-      return '#696969'; // Dim grey
-    case ZoneType.Restricted:
-      return '#ff69b4'; // Hot pink
-    default:
-      return '#ffffff'; // White
-  }
-}
-
-/**
- * Limits for custom line widths
- */
-const LINE_WIDTH_LIMITS = {
-  min: 1,
-  max: 12,
-};
-
-/**
- * Custom rendering styles for geometry displayed on the map
- */
-const styleGeneratorMap: StyleGeneratorMap = {
-  /**
-   * Style for draggable point annotations
-   */
-  draggablePoint: (
-    role: CoordinateRole,
-    feature: EditableFeature
-  ): DraggablePointStyle => {
-    let style = defaultStyleGeneratorMap.draggablePoint(role, feature);
-    if (feature.geometry.type === 'Point') {
-      style.color = vehicleTypeColor(feature.properties?.vehicleType);
-    }
-    return style;
-  },
-  /**
-   * Style for selected vertices of shapes being edited
-   */
-  selectedVertex: defaultStyleGeneratorMap.selectedVertex,
-  /**
-   * Style for point geometry, non-clusters
-   */
-  point: () => {
-    let style = defaultStyleGeneratorMap.point();
-    /**
-     * Data-driven styling by vehicle type
-     */
-    style.circleColor = [
-      'match',
-      ['get', 'vehicleType'],
-      VehicleType.Car,
-      vehicleTypeColor(VehicleType.Car),
-      VehicleType.Train,
-      vehicleTypeColor(VehicleType.Train),
-      VehicleType.Boat,
-      vehicleTypeColor(VehicleType.Boat),
-      VehicleType.Bicycle,
-      vehicleTypeColor(VehicleType.Bicycle),
-      vehicleTypeColor(), // Default
-    ];
-    return style;
-  },
-  /**
-   * Style for vertices of non-point geometry
-   */
-  vertex: defaultStyleGeneratorMap.vertex,
-  /**
-   * Style for polylines describing the edges of non-polyline geometry
-   */
-  edge: defaultStyleGeneratorMap.edge,
-  /**
-   * Style for polygon geometry
-   */
-  polygon: () => {
-    let style = defaultStyleGeneratorMap.polygon();
-    /**
-     * Data-driven styling by geometry lifecycle stage and zone type
-     */
-    style.fillColor = [
-      'match',
-      ['get', 'rnmgeStage'],
-      FeatureLifecycleStage.NewShape,
-      featureLifecycleStageColor(FeatureLifecycleStage.NewShape),
-      FeatureLifecycleStage.EditShape,
-      featureLifecycleStageColor(FeatureLifecycleStage.EditShape),
-      FeatureLifecycleStage.EditMetadata,
-      featureLifecycleStageColor(FeatureLifecycleStage.EditMetadata),
-      FeatureLifecycleStage.SelectMultiple,
-      featureLifecycleStageColor(FeatureLifecycleStage.SelectMultiple),
-      FeatureLifecycleStage.SelectSingle,
-      featureLifecycleStageColor(FeatureLifecycleStage.SelectSingle),
-      FeatureLifecycleStage.View,
-      [
-        'match',
-        ['get', 'zoneType'],
-        ZoneType.Parking,
-        zoneTypeColor(ZoneType.Parking),
-        ZoneType.Restricted,
-        zoneTypeColor(ZoneType.Restricted),
-        zoneTypeColor(), // Default
-      ],
-      zoneTypeColor(), // Default
-    ];
-    return style;
-  },
-  /**
-   * Style for polyline geometry
-   */
-  polyline: () => {
-    let style = defaultStyleGeneratorMap.polyline();
-    /**
-     * Data-driven styling: Set the width of the line to the value given
-     * by its custom 'width' property, clipped to the range 1-12.
-     */
-    style.lineWidth = [
-      'interpolate',
-      ['linear'],
-      ['get', 'width'],
-      LINE_WIDTH_LIMITS.min,
-      LINE_WIDTH_LIMITS.min,
-      LINE_WIDTH_LIMITS.max,
-      LINE_WIDTH_LIMITS.max,
-    ];
-    return style;
-  },
-  /**
-   * Style for clustered point geometry
-   */
-  cluster: () => {
-    let style = defaultStyleGeneratorMap.cluster();
-    style.circleStrokeColor = 'tan';
-    style.circleStrokeWidth = 4;
-    return style;
-  },
-  /**
-   * Style for symbols rendered on top of clusters
-   * (defaults to cluster point counts rendered as text)
-   */
-  clusterSymbol: () => {
-    return defaultStyleGeneratorMap.clusterSymbol();
-  },
-};
-
-/**
- * Custom metadata fields for point geometry
- */
-const POINT_SCHEMA = [
-  ['yup.object'],
-  ['yup.required'],
-  [
-    'yup.meta',
-    {
-      titleFieldKey: 'model',
-      title: 'No model',
-      showIfEmpty: false,
-    },
-  ],
-  [
-    'yup.shape',
-    {
-      vehicleType: [
-        ['yup.mixed'],
-        ['yup.label', 'Type of vehicle'],
-        ['yup.required'],
-        ['yup.oneOf', Object.values(VehicleType)],
-        [
-          'yup.meta',
-          {
-            inPreview: true,
-          },
-        ],
-      ],
-      model: [['yup.string'], ['yup.required', 'A model is required']], // An enumeration may be better, as the user could input arbitrary strings
-      age: [
-        ['yup.number'],
-        ['yup.label', 'Age (years)'],
-        ['yup.required', 'How old is it?'],
-        ['yup.positive', 'Age must be greater than zero'],
-      ],
-      description: [
-        ['yup.string'],
-        ['yup.label', 'Description'],
-        ['yup.optional'],
-        [
-          'yup.meta',
-          {
-            inPreview: true,
-          },
-        ],
-      ],
-      needsRepair: [
-        ['yup.boolean'],
-        ['yup.label', 'Needs repair?'],
-        ['yup.required'],
-      ],
-      fieldWithPermissions: [
-        ['yup.string'],
-        ['yup.label', 'Immutable comment'],
-        ['yup.optional'],
-        [
-          'yup.meta',
-          {
-            permissions: {
-              edit: false,
-            },
-            showIfEmpty: true,
-          },
-        ],
-      ],
-    },
-  ],
-];
-
-/**
- * For development purposes, validate the metadata schema
- */
-const validationResult = validateMetadata(POINT_SCHEMA, {
-  vehicleType: 'BICYCLE',
-  model: 'classic',
-  age: 'five',
-  extraProperties: {
-    wheelDiameter: 26,
-  },
-});
-if (validationResult.schemaErrors) {
-  console.warn(
-    'Example metadata schema errors: ',
-    validationResult.schemaErrors
-  );
-}
-if (validationResult.dataErrors) {
-  console.warn(
-    'Example metadata data validation errors: ',
-    validationResult.dataErrors
-  );
-}
-
-/**
  * The time interval over which camera transitions will occur.
  */
 const cameraMoveTime = 200; // Milliseconds
@@ -394,37 +85,30 @@ function IOControls({
   drawPolygon,
   drawPolyline,
   drawPoint,
-  edit,
   confirm,
   cancel,
-  deleteShapeOrPoint,
   undo,
   redo,
   canUndo,
   canRedo,
-  cannotUndoAndRedo,
-  canDelete,
   hasCompleteNewFeature,
+  setCustomUI,
 }: {
   drawPolygon: () => void;
   drawPolyline: () => void;
   drawPoint: () => void;
-  edit: () => void;
   confirm: () => void;
   cancel: () => void;
-  deleteShapeOrPoint: () => void;
   undo: () => void;
   redo: () => void;
   canUndo: boolean;
   canRedo: boolean;
-  cannotUndoAndRedo: boolean;
-  canDelete: boolean;
   hasCompleteNewFeature: boolean;
+  setCustomUI: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   let buttonColor = 'orange';
   let undoColor = 'orange';
   let redoColor = 'orange';
-  let deleteColor = 'orange';
   let confirmColor = 'orange';
   if (!canUndo) {
     undoColor = 'grey';
@@ -432,83 +116,120 @@ function IOControls({
   if (!canRedo) {
     redoColor = 'grey';
   }
-  if (cannotUndoAndRedo || !hasCompleteNewFeature) {
+  if (!hasCompleteNewFeature) {
     confirmColor = 'grey';
   }
-  if (!canDelete) {
-    deleteColor = 'grey';
-  }
+
+  const [toggleDrawButtons, setToggleDrawButtons] = useState(true);
+
+  /**
+   * Displays buttons for selecting a draw mode or controlling the shape currently being drawn
+   */
+  const drawingButtons = () => {
+    if (toggleDrawButtons) {
+      return (
+        <View style={styles.ioControlsContainer}>
+          <Pressable
+            style={[styles.button, { backgroundColor: buttonColor }]}
+            onPress={() => {
+              drawPolygon();
+              setToggleDrawButtons(false);
+            }}
+          >
+            <Text style={styles.text}>Draw Polygon</Text>
+          </Pressable>
+          <Pressable
+            style={[styles.button, { backgroundColor: buttonColor }]}
+            onPress={() => {
+              drawPolyline();
+              setToggleDrawButtons(false);
+            }}
+            disabled={false}
+          >
+            <Text style={styles.text}>Draw Polyline</Text>
+          </Pressable>
+          <Pressable
+            style={[styles.button, { backgroundColor: buttonColor }]}
+            onPress={() => {
+              drawPoint();
+            }}
+            disabled={false}
+          >
+            <Text style={styles.text}>Draw Point</Text>
+          </Pressable>
+        </View>
+      );
+    } else {
+      return (
+        <View style={styles.ioControlsContainer}>
+          <View>
+            <Pressable
+              style={[styles.button, { backgroundColor: confirmColor }]}
+              onPress={() => {
+                confirm();
+                setToggleDrawButtons(true);
+              }}
+              disabled={!hasCompleteNewFeature}
+            >
+              <Text style={styles.text}>Confirm</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.button, { backgroundColor: buttonColor }]}
+              onPress={() => {
+                cancel();
+                setToggleDrawButtons(true);
+              }}
+            >
+              <Text style={styles.text}>Cancel</Text>
+            </Pressable>
+          </View>
+          <View>
+            <Pressable
+              style={[styles.button, { backgroundColor: redoColor }]}
+              onPress={redo}
+              disabled={!canRedo}
+            >
+              <Text style={styles.text}>Redo</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.button, { backgroundColor: undoColor }]}
+              onPress={undo}
+              disabled={!canUndo}
+            >
+              <Text style={styles.text}>Undo</Text>
+            </Pressable>
+          </View>
+        </View>
+      );
+    }
+  };
 
   return (
-    <View style={styles.ioControlsContainer}>
-      <Pressable
-        style={[styles.button, { backgroundColor: buttonColor }]}
-        onPress={drawPolygon}
-      >
-        <Text style={styles.text}>Draw Polygon</Text>
-      </Pressable>
-      <Pressable
-        style={[styles.button, { backgroundColor: buttonColor }]}
-        onPress={drawPolyline}
-        disabled={false}
-      >
-        <Text style={styles.text}>Draw Polyline</Text>
-      </Pressable>
-      <Pressable
-        style={[styles.button, { backgroundColor: buttonColor }]}
-        onPress={drawPoint}
-        disabled={false}
-      >
-        <Text style={styles.text}>Draw Point</Text>
-      </Pressable>
-      <Pressable
-        style={[styles.button, { backgroundColor: confirmColor }]}
-        onPress={confirm}
-        disabled={!hasCompleteNewFeature || cannotUndoAndRedo}
-      >
-        <Text style={styles.text}>Confirm</Text>
-      </Pressable>
-      <Pressable
-        style={[styles.button, { backgroundColor: buttonColor }]}
-        onPress={cancel}
-      >
-        <Text style={styles.text}>Cancel</Text>
-      </Pressable>
-      <Pressable
-        style={[styles.button, { backgroundColor: undoColor }]}
-        onPress={undo}
-        disabled={!canUndo}
-      >
-        <Text style={styles.text}>Undo</Text>
-      </Pressable>
-      <Pressable
-        style={[styles.button, { backgroundColor: redoColor }]}
-        onPress={redo}
-        disabled={!canRedo}
-      >
-        <Text style={styles.text}>Redo</Text>
-      </Pressable>
-      <Pressable
-        style={[styles.button, { backgroundColor: deleteColor }]}
-        onPress={deleteShapeOrPoint}
-        disabled={!canDelete}
-      >
-        <Text style={styles.text}>Delete</Text>
-      </Pressable>
-      <Pressable
-        style={[styles.button, { backgroundColor: buttonColor }]}
-        onPress={edit}
-      >
-        <Text style={styles.text}>Edit</Text>
-      </Pressable>
+    <View style={styles.buttonContainer}>
+      <View>
+        <Pressable
+          style={[styles.button, { backgroundColor: buttonColor }]}
+          onPress={() => setCustomUI((prevValue) => !prevValue)}
+        >
+          <Text style={styles.text}>Toggle UI</Text>
+        </Pressable>
+      </View>
+      {drawingButtons()}
     </View>
   );
 }
 
 /**
- * Render a map page with a demonstration of the geometry editor library's functionality
+ * Render a map page with a demonstration of the geometry editor library custom UI functionality
  */
-export default function App() {
+export function CustomUIApp({
+  setCustomUI,
+}: {
+  /**
+   * Set whether or not to display a custom UI or the default UI
+   */
+  setCustomUI: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
   /**
    * Receive hints from the geometry editor, about where the camera should be looking,
    * that are triggered by certain user actions.
@@ -535,8 +256,6 @@ export default function App() {
    */
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
-  const [cannotUndoAndRedo, setCannotUndoAndRedo] = useState(false);
-  const [canDelete, setCanDelete] = useState(false);
   const [hasCompleteNewFeature, setHasCompleteNewFeature] = useState(false);
 
   /**
@@ -588,78 +307,6 @@ export default function App() {
      * Select the top shape in the Geometry Editor without having to tap on it
      */
     selectTopShape: () => ioRef.current?.selectTopShape(),
-    onImport: () => {
-      (async () => {
-        if (ioRef.current) {
-          /**
-           * Time the import operation and display the time in an alert
-           */
-          const t0 = getTimeMilliseconds();
-          try {
-            const result = await ioRef.current.import(
-              sampleFeatures as FeatureCollection,
-              {
-                replace: true,
-                strict: false,
-                validate: true,
-              }
-            );
-
-            const t1 = getTimeMilliseconds();
-            Alert.alert(
-              'Import result',
-              `Data imported ${result.exact ? 'exactly' : 'with changes'} in ${
-                t1 - t0
-              } milliseconds with ${result?.errors.length} errors.`
-            );
-          } catch (e) {
-            console.error(e);
-            let message = 'Unknown error';
-            if (e instanceof Error) {
-              message = e.message;
-            }
-            Alert.alert('Import failed', message);
-          }
-        }
-      })();
-    },
-    onExport: () => {
-      (async () => {
-        if (ioRef.current) {
-          /**
-           * Time the export operation and display the time in an alert
-           */
-          const t0 = getTimeMilliseconds();
-          try {
-            const result = await ioRef.current.export();
-            const jsonResult = JSON.stringify(result, null, 1);
-            /**
-             * Avoid flooding the console with the result
-             */
-            if (jsonResult.length < 10000) {
-              console.log('Export result: \n', jsonResult);
-            } else {
-              console.log(
-                `Stringified export result (with whitespace) has ${jsonResult.length} characters (not shown).`
-              );
-            }
-
-            const t1 = getTimeMilliseconds();
-            Alert.alert(
-              'Export result',
-              `Data exported in ${t1 - t0} milliseconds.`
-            );
-          } catch (e) {
-            console.error(e);
-            let message = 'Unknown error';
-            if (e instanceof Error) {
-              message = e.message;
-            }
-            Alert.alert('Export failed', message);
-          }
-        }
-      })();
-    },
   };
 
   return (
@@ -667,9 +314,8 @@ export default function App() {
       <IOControls
         canUndo={canUndo}
         canRedo={canRedo}
-        cannotUndoAndRedo={cannotUndoAndRedo}
-        canDelete={canDelete}
         hasCompleteNewFeature={hasCompleteNewFeature}
+        setCustomUI={setCustomUI}
         {...ioHandlers}
       />
       <GeometryEditor
@@ -678,13 +324,10 @@ export default function App() {
           style: styles.map,
           styleURL: 'mapbox://styles/mapbox/dark-v10',
         }}
-        styleGenerators={styleGeneratorMap}
         ref={ioRef}
         isCustomUI={true}
         setCanRedo={setCanRedo}
         setCanUndo={setCanUndo}
-        setCanDelete={setCanDelete}
-        setCannotUndoAndRedo={setCannotUndoAndRedo}
         setHasCompleteNewFeature={setHasCompleteNewFeature}
       >
         <MapboxGL.Camera

--- a/example/src/CustomUIApp.tsx
+++ b/example/src/CustomUIApp.tsx
@@ -1,0 +1,698 @@
+/**
+ * React Native Mapbox geometry editor custom UI example
+ */
+
+import { useMemo, useRef, useState } from 'react';
+import {
+  Alert,
+  LogBox,
+  SafeAreaView,
+  StyleSheet,
+  View,
+  Pressable,
+  Text,
+} from 'react-native';
+
+import MapboxGL from '@rnmapbox/maps';
+
+import token from '../mapbox_token.json';
+import sampleFeatures from './sample.json';
+import type { FeatureCollection } from 'geojson';
+
+/**
+ * A way to get the `performance.now()` interface, for timing code,
+ * in both debug and release mode
+ * See https://github.com/MaxGraey/react-native-console-time-polyfill/blob/master/index.js
+ */
+const getTimeMilliseconds =
+  ((global as any).performance && (global as any).performance.now) ||
+  (global as any).performanceNow ||
+  (global as any).nativePerformanceNow;
+if (!getTimeMilliseconds) {
+  throw new Error('Failed to find performance.now() or an equivalent.');
+}
+
+/**
+ * Hide known issue in the library (refer to the README)
+ */
+LogBox.ignoreLogs([
+  "[mobx] Derivation 'observer_StoreProvider' is created/updated without reading any observable value.",
+]);
+
+/**
+ * Polyfill for React Native needed by 'react-native-mapbox-geometry-editor'
+ * See https://github.com/uuidjs/uuid#getrandomvalues-not-supported
+ */
+import 'react-native-get-random-values';
+import {
+  defaultStyleGeneratorMap,
+  FeatureLifecycleStage,
+  featureLifecycleStageColor,
+  CoordinateRole,
+  validateMetadata,
+  GeometryEditor,
+} from 'react-native-mapbox-geometry-editor';
+import type {
+  CameraControls,
+  DraggablePointStyle,
+  EditableFeature,
+  GeometryIORef,
+  StyleGeneratorMap,
+} from 'react-native-mapbox-geometry-editor';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'green',
+  },
+  libraryContainer: {
+    margin: 10,
+    borderRadius: 15,
+    overflow: 'hidden',
+    flex: 1,
+    backgroundColor: 'blue',
+  },
+  map: {
+    overflow: 'hidden',
+  },
+  ioControlsContainer: {
+    flexWrap: 'wrap',
+    flexDirection: 'row',
+  },
+  button: {
+    marginBottom: 5,
+    marginRight: 10,
+    padding: 3,
+    borderRadius: 10,
+  },
+  text: {
+    textAlign: 'center',
+  },
+});
+
+/* Set the Mapbox API access token
+ * Changes to the token might only take effect after closing and reopening the app.
+ * (see https://github.com/rnmapbox/maps/issues/933)
+ */
+MapboxGL.setAccessToken(token.accessToken);
+
+/**
+ * Example enumeration used for an option select
+ * geometry metadata field
+ *
+ * Also used for data-driven geometry styling
+ */
+enum VehicleType {
+  Car = 'CAR',
+  Train = 'TRAIN',
+  Boat = 'BOAT',
+  Bicycle = 'BICYCLE',
+}
+
+/**
+ * Default colours for vehicle types
+ * @param stage The vehicle type
+ * @return A specific or a default colour, depending on whether `type` is defined
+ */
+function vehicleTypeColor(type?: VehicleType): string {
+  switch (type) {
+    case VehicleType.Car:
+      return '#ff1493'; // Deep pink
+    case VehicleType.Train:
+      return '#adff2f'; // Green yellow
+    case VehicleType.Boat:
+      return '#0000cd'; // Medium blue
+    case VehicleType.Bicycle:
+      return '#f4a460'; // Sandy brown
+    default:
+      return '#ffffff'; // White
+  }
+}
+
+/**
+ * Enumeration for data-driven styling of polygons
+ */
+enum ZoneType {
+  Parking = 'PARKING',
+  Restricted = 'RESTRICTED',
+}
+
+/**
+ * Default colours for {@link ZoneType} types
+ * @param stage The zone type
+ * @return A specific or a default colour, depending on whether `type` is defined
+ */
+function zoneTypeColor(type?: ZoneType): string {
+  switch (type) {
+    case ZoneType.Parking:
+      return '#696969'; // Dim grey
+    case ZoneType.Restricted:
+      return '#ff69b4'; // Hot pink
+    default:
+      return '#ffffff'; // White
+  }
+}
+
+/**
+ * Limits for custom line widths
+ */
+const LINE_WIDTH_LIMITS = {
+  min: 1,
+  max: 12,
+};
+
+/**
+ * Custom rendering styles for geometry displayed on the map
+ */
+const styleGeneratorMap: StyleGeneratorMap = {
+  /**
+   * Style for draggable point annotations
+   */
+  draggablePoint: (
+    role: CoordinateRole,
+    feature: EditableFeature
+  ): DraggablePointStyle => {
+    let style = defaultStyleGeneratorMap.draggablePoint(role, feature);
+    if (feature.geometry.type === 'Point') {
+      style.color = vehicleTypeColor(feature.properties?.vehicleType);
+    }
+    return style;
+  },
+  /**
+   * Style for selected vertices of shapes being edited
+   */
+  selectedVertex: defaultStyleGeneratorMap.selectedVertex,
+  /**
+   * Style for point geometry, non-clusters
+   */
+  point: () => {
+    let style = defaultStyleGeneratorMap.point();
+    /**
+     * Data-driven styling by vehicle type
+     */
+    style.circleColor = [
+      'match',
+      ['get', 'vehicleType'],
+      VehicleType.Car,
+      vehicleTypeColor(VehicleType.Car),
+      VehicleType.Train,
+      vehicleTypeColor(VehicleType.Train),
+      VehicleType.Boat,
+      vehicleTypeColor(VehicleType.Boat),
+      VehicleType.Bicycle,
+      vehicleTypeColor(VehicleType.Bicycle),
+      vehicleTypeColor(), // Default
+    ];
+    return style;
+  },
+  /**
+   * Style for vertices of non-point geometry
+   */
+  vertex: defaultStyleGeneratorMap.vertex,
+  /**
+   * Style for polylines describing the edges of non-polyline geometry
+   */
+  edge: defaultStyleGeneratorMap.edge,
+  /**
+   * Style for polygon geometry
+   */
+  polygon: () => {
+    let style = defaultStyleGeneratorMap.polygon();
+    /**
+     * Data-driven styling by geometry lifecycle stage and zone type
+     */
+    style.fillColor = [
+      'match',
+      ['get', 'rnmgeStage'],
+      FeatureLifecycleStage.NewShape,
+      featureLifecycleStageColor(FeatureLifecycleStage.NewShape),
+      FeatureLifecycleStage.EditShape,
+      featureLifecycleStageColor(FeatureLifecycleStage.EditShape),
+      FeatureLifecycleStage.EditMetadata,
+      featureLifecycleStageColor(FeatureLifecycleStage.EditMetadata),
+      FeatureLifecycleStage.SelectMultiple,
+      featureLifecycleStageColor(FeatureLifecycleStage.SelectMultiple),
+      FeatureLifecycleStage.SelectSingle,
+      featureLifecycleStageColor(FeatureLifecycleStage.SelectSingle),
+      FeatureLifecycleStage.View,
+      [
+        'match',
+        ['get', 'zoneType'],
+        ZoneType.Parking,
+        zoneTypeColor(ZoneType.Parking),
+        ZoneType.Restricted,
+        zoneTypeColor(ZoneType.Restricted),
+        zoneTypeColor(), // Default
+      ],
+      zoneTypeColor(), // Default
+    ];
+    return style;
+  },
+  /**
+   * Style for polyline geometry
+   */
+  polyline: () => {
+    let style = defaultStyleGeneratorMap.polyline();
+    /**
+     * Data-driven styling: Set the width of the line to the value given
+     * by its custom 'width' property, clipped to the range 1-12.
+     */
+    style.lineWidth = [
+      'interpolate',
+      ['linear'],
+      ['get', 'width'],
+      LINE_WIDTH_LIMITS.min,
+      LINE_WIDTH_LIMITS.min,
+      LINE_WIDTH_LIMITS.max,
+      LINE_WIDTH_LIMITS.max,
+    ];
+    return style;
+  },
+  /**
+   * Style for clustered point geometry
+   */
+  cluster: () => {
+    let style = defaultStyleGeneratorMap.cluster();
+    style.circleStrokeColor = 'tan';
+    style.circleStrokeWidth = 4;
+    return style;
+  },
+  /**
+   * Style for symbols rendered on top of clusters
+   * (defaults to cluster point counts rendered as text)
+   */
+  clusterSymbol: () => {
+    return defaultStyleGeneratorMap.clusterSymbol();
+  },
+};
+
+/**
+ * Custom metadata fields for point geometry
+ */
+const POINT_SCHEMA = [
+  ['yup.object'],
+  ['yup.required'],
+  [
+    'yup.meta',
+    {
+      titleFieldKey: 'model',
+      title: 'No model',
+      showIfEmpty: false,
+    },
+  ],
+  [
+    'yup.shape',
+    {
+      vehicleType: [
+        ['yup.mixed'],
+        ['yup.label', 'Type of vehicle'],
+        ['yup.required'],
+        ['yup.oneOf', Object.values(VehicleType)],
+        [
+          'yup.meta',
+          {
+            inPreview: true,
+          },
+        ],
+      ],
+      model: [['yup.string'], ['yup.required', 'A model is required']], // An enumeration may be better, as the user could input arbitrary strings
+      age: [
+        ['yup.number'],
+        ['yup.label', 'Age (years)'],
+        ['yup.required', 'How old is it?'],
+        ['yup.positive', 'Age must be greater than zero'],
+      ],
+      description: [
+        ['yup.string'],
+        ['yup.label', 'Description'],
+        ['yup.optional'],
+        [
+          'yup.meta',
+          {
+            inPreview: true,
+          },
+        ],
+      ],
+      needsRepair: [
+        ['yup.boolean'],
+        ['yup.label', 'Needs repair?'],
+        ['yup.required'],
+      ],
+      fieldWithPermissions: [
+        ['yup.string'],
+        ['yup.label', 'Immutable comment'],
+        ['yup.optional'],
+        [
+          'yup.meta',
+          {
+            permissions: {
+              edit: false,
+            },
+            showIfEmpty: true,
+          },
+        ],
+      ],
+    },
+  ],
+];
+
+/**
+ * For development purposes, validate the metadata schema
+ */
+const validationResult = validateMetadata(POINT_SCHEMA, {
+  vehicleType: 'BICYCLE',
+  model: 'classic',
+  age: 'five',
+  extraProperties: {
+    wheelDiameter: 26,
+  },
+});
+if (validationResult.schemaErrors) {
+  console.warn(
+    'Example metadata schema errors: ',
+    validationResult.schemaErrors
+  );
+}
+if (validationResult.dataErrors) {
+  console.warn(
+    'Example metadata data validation errors: ',
+    validationResult.dataErrors
+  );
+}
+
+/**
+ * The time interval over which camera transitions will occur.
+ */
+const cameraMoveTime = 200; // Milliseconds
+
+/**
+ * A component that renders buttons for controlling the Geometry Editor externally
+ * geometry
+ * @param props Render properties
+ */
+function IOControls({
+  drawPolygon,
+  drawPolyline,
+  drawPoint,
+  edit,
+  confirm,
+  cancel,
+  deleteShapeOrPoint,
+  undo,
+  redo,
+  canUndo,
+  canRedo,
+  cannotUndoAndRedo,
+  canDelete,
+  hasCompleteNewFeature,
+}: {
+  drawPolygon: () => void;
+  drawPolyline: () => void;
+  drawPoint: () => void;
+  edit: () => void;
+  confirm: () => void;
+  cancel: () => void;
+  deleteShapeOrPoint: () => void;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  cannotUndoAndRedo: boolean;
+  canDelete: boolean;
+  hasCompleteNewFeature: boolean;
+}) {
+  let buttonColor = 'orange';
+  let undoColor = 'orange';
+  let redoColor = 'orange';
+  let deleteColor = 'orange';
+  let confirmColor = 'orange';
+  if (!canUndo) {
+    undoColor = 'grey';
+  }
+  if (!canRedo) {
+    redoColor = 'grey';
+  }
+  if (cannotUndoAndRedo || !hasCompleteNewFeature) {
+    confirmColor = 'grey';
+  }
+  if (!canDelete) {
+    deleteColor = 'grey';
+  }
+
+  return (
+    <View style={styles.ioControlsContainer}>
+      <Pressable
+        style={[styles.button, { backgroundColor: buttonColor }]}
+        onPress={drawPolygon}
+      >
+        <Text style={styles.text}>Draw Polygon</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.button, { backgroundColor: buttonColor }]}
+        onPress={drawPolyline}
+        disabled={false}
+      >
+        <Text style={styles.text}>Draw Polyline</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.button, { backgroundColor: buttonColor }]}
+        onPress={drawPoint}
+        disabled={false}
+      >
+        <Text style={styles.text}>Draw Point</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.button, { backgroundColor: confirmColor }]}
+        onPress={confirm}
+        disabled={!hasCompleteNewFeature || cannotUndoAndRedo}
+      >
+        <Text style={styles.text}>Confirm</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.button, { backgroundColor: buttonColor }]}
+        onPress={cancel}
+      >
+        <Text style={styles.text}>Cancel</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.button, { backgroundColor: undoColor }]}
+        onPress={undo}
+        disabled={!canUndo}
+      >
+        <Text style={styles.text}>Undo</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.button, { backgroundColor: redoColor }]}
+        onPress={redo}
+        disabled={!canRedo}
+      >
+        <Text style={styles.text}>Redo</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.button, { backgroundColor: deleteColor }]}
+        onPress={deleteShapeOrPoint}
+        disabled={!canDelete}
+      >
+        <Text style={styles.text}>Delete</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.button, { backgroundColor: buttonColor }]}
+        onPress={edit}
+      >
+        <Text style={styles.text}>Edit</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+/**
+ * Render a map page with a demonstration of the geometry editor library's functionality
+ */
+export default function App() {
+  /**
+   * Receive hints from the geometry editor, about where the camera should be looking,
+   * that are triggered by certain user actions.
+   */
+  const cameraRef = useRef<MapboxGL.Camera>(null);
+  const cameraControls: CameraControls = useMemo(() => {
+    return {
+      fitBounds: (northEastCoordinates, southWestCoordinates, padding) => {
+        cameraRef.current?.fitBounds(
+          northEastCoordinates,
+          southWestCoordinates,
+          padding,
+          cameraMoveTime
+        );
+      },
+      moveTo: (coordinates) => {
+        cameraRef.current?.moveTo(coordinates, cameraMoveTime);
+      },
+    };
+  }, [cameraRef]);
+
+  /**
+   * States that contain important information for the Geometry Editor buttons
+   */
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+  const [cannotUndoAndRedo, setCannotUndoAndRedo] = useState(false);
+  const [canDelete, setCanDelete] = useState(false);
+  const [hasCompleteNewFeature, setHasCompleteNewFeature] = useState(false);
+
+  /**
+   * Geometry import and export functionality
+   */
+  const ioRef = useRef<GeometryIORef>(null);
+  const ioHandlers = {
+    /**
+     * Place the Geometry Editor in draw polygon mode
+     */
+    drawPolygon: () => ioRef.current?.drawPolygon(),
+    /**
+     * Place the Geometry Editor in draw polyline mode
+     */
+    drawPolyline: () => ioRef.current?.drawPolyline(),
+    /**
+     * Place the Geometry Editor in draw point mode
+     */
+    drawPoint: () => ioRef.current?.drawPoint(),
+    /**
+     * Confirm the latest action in the Geometry Editor
+     */
+    confirm: () => ioRef.current?.confirm(),
+    /**
+     * Cancel the latest action in the Geometry Editor
+     */
+    cancel: () => ioRef.current?.cancel(),
+    /**
+     * Undo the latest action in the Geometry Editor
+     */
+    undo: () => ioRef.current?.undo(),
+    /**
+     * Redo the latest action in the Geometry Editor
+     */
+    redo: () => ioRef.current?.redo(),
+    /**
+     * Delete the selected shape or point in the Geometry Editor
+     */
+    deleteShapeOrPoint: () => ioRef.current?.deleteShapeOrPoint(),
+    /**
+     * Place the Geometry Editor in select mode
+     */
+    selectSingleShape: () => ioRef.current?.selectSingleShape(),
+    /**
+     * Place the Geometry Editor in edit mode
+     */
+    edit: () => ioRef.current?.edit(),
+    /**
+     * Select the top shape in the Geometry Editor without having to tap on it
+     */
+    selectTopShape: () => ioRef.current?.selectTopShape(),
+    onImport: () => {
+      (async () => {
+        if (ioRef.current) {
+          /**
+           * Time the import operation and display the time in an alert
+           */
+          const t0 = getTimeMilliseconds();
+          try {
+            const result = await ioRef.current.import(
+              sampleFeatures as FeatureCollection,
+              {
+                replace: true,
+                strict: false,
+                validate: true,
+              }
+            );
+
+            const t1 = getTimeMilliseconds();
+            Alert.alert(
+              'Import result',
+              `Data imported ${result.exact ? 'exactly' : 'with changes'} in ${
+                t1 - t0
+              } milliseconds with ${result?.errors.length} errors.`
+            );
+          } catch (e) {
+            console.error(e);
+            let message = 'Unknown error';
+            if (e instanceof Error) {
+              message = e.message;
+            }
+            Alert.alert('Import failed', message);
+          }
+        }
+      })();
+    },
+    onExport: () => {
+      (async () => {
+        if (ioRef.current) {
+          /**
+           * Time the export operation and display the time in an alert
+           */
+          const t0 = getTimeMilliseconds();
+          try {
+            const result = await ioRef.current.export();
+            const jsonResult = JSON.stringify(result, null, 1);
+            /**
+             * Avoid flooding the console with the result
+             */
+            if (jsonResult.length < 10000) {
+              console.log('Export result: \n', jsonResult);
+            } else {
+              console.log(
+                `Stringified export result (with whitespace) has ${jsonResult.length} characters (not shown).`
+              );
+            }
+
+            const t1 = getTimeMilliseconds();
+            Alert.alert(
+              'Export result',
+              `Data exported in ${t1 - t0} milliseconds.`
+            );
+          } catch (e) {
+            console.error(e);
+            let message = 'Unknown error';
+            if (e instanceof Error) {
+              message = e.message;
+            }
+            Alert.alert('Export failed', message);
+          }
+        }
+      })();
+    },
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <IOControls
+        canUndo={canUndo}
+        canRedo={canRedo}
+        cannotUndoAndRedo={cannotUndoAndRedo}
+        canDelete={canDelete}
+        hasCompleteNewFeature={hasCompleteNewFeature}
+        {...ioHandlers}
+      />
+      <GeometryEditor
+        cameraControls={cameraControls}
+        mapProps={{
+          style: styles.map,
+          styleURL: 'mapbox://styles/mapbox/dark-v10',
+        }}
+        styleGenerators={styleGeneratorMap}
+        ref={ioRef}
+        isCustomUI={true}
+        setCanRedo={setCanRedo}
+        setCanUndo={setCanUndo}
+        setCanDelete={setCanDelete}
+        setCannotUndoAndRedo={setCannotUndoAndRedo}
+        setHasCompleteNewFeature={setHasCompleteNewFeature}
+      >
+        <MapboxGL.Camera
+          ref={cameraRef}
+          centerCoordinate={[3.380271, 6.464217]}
+          zoomLevel={14}
+        />
+      </GeometryEditor>
+    </SafeAreaView>
+  );
+}

--- a/src/component/GeometryEditor.tsx
+++ b/src/component/GeometryEditor.tsx
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 import { Observer } from 'mobx-react-lite';
-import { action, autorun } from 'mobx';
+import { action } from 'mobx';
 import { forwardRef, useContext, useMemo } from 'react';
 import type { ReactNode, Ref } from 'react';
 import { StyleSheet } from 'react-native';

--- a/src/component/GeometryEditor.tsx
+++ b/src/component/GeometryEditor.tsx
@@ -4,7 +4,7 @@
  */
 import { Observer } from 'mobx-react-lite';
 import { action } from 'mobx';
-import { forwardRef, useContext, useMemo } from 'react';
+import { forwardRef, useContext, useEffect, useMemo } from 'react';
 import type { ReactNode, Ref } from 'react';
 import { StyleSheet } from 'react-native';
 import MapboxGL, { MapViewProps } from '@rnmapbox/maps';
@@ -107,7 +107,11 @@ function GeometryEditorComponent(
   const setCustomUIProperty = action('set_custom_ui', () => {
     return store.setCustomUI(isCustomUI);
   });
-  setCustomUIProperty();
+  useEffect(() => {
+    if (store.controls.isCustomUI !== isCustomUI) {
+      setCustomUIProperty();
+    }
+  }, [store.controls.isCustomUI, setCustomUIProperty, isCustomUI]);
 
   /**
    * A touch callback for the map that will add a new point

--- a/src/component/GeometryEditor.tsx
+++ b/src/component/GeometryEditor.tsx
@@ -64,6 +64,10 @@ export interface GeometryEditorProps {
    * Additional child elements to render as children of the map
    */
   readonly children?: ReactNode;
+  /**
+   * Whether or not the Geometry Editor is using a custom UI, if left blank it will assume false
+   */
+  isCustomUI?: boolean;
 }
 
 /**
@@ -94,10 +98,17 @@ function GeometryEditorComponent(
     aboveLayerID,
     mapProps = {},
     styleGenerators = defaultStyleGeneratorMap,
+    isCustomUI,
   } = props;
   const { style: mapStyle, onPress: outerOnPress, ...restMapProps } = mapProps;
 
   const store = useContext(StoreContext);
+
+  const setCustomUIProperty = action('set_custom_ui', () => {
+    return store.setCustomUI(isCustomUI);
+  });
+  setCustomUIProperty();
+
   /**
    * A touch callback for the map that will add a new point
    */

--- a/src/component/GeometryEditor.tsx
+++ b/src/component/GeometryEditor.tsx
@@ -4,7 +4,7 @@
  */
 import { Observer } from 'mobx-react-lite';
 import { action } from 'mobx';
-import { forwardRef, useContext, useEffect, useMemo } from 'react';
+import { forwardRef, useContext, useMemo } from 'react';
 import type { ReactNode, Ref } from 'react';
 import { StyleSheet } from 'react-native';
 import MapboxGL, { MapViewProps } from '@rnmapbox/maps';
@@ -107,11 +107,9 @@ function GeometryEditorComponent(
   const setCustomUIProperty = action('set_custom_ui', () => {
     return store.setCustomUI(isCustomUI);
   });
-  useEffect(() => {
-    if (store.controls.isCustomUI !== isCustomUI) {
-      setCustomUIProperty();
-    }
-  }, [store.controls.isCustomUI, setCustomUIProperty, isCustomUI]);
+  if (store.controls.isCustomUI !== isCustomUI) {
+    setCustomUIProperty();
+  }
 
   /**
    * A touch callback for the map that will add a new point

--- a/src/component/GeometryEditor.tsx
+++ b/src/component/GeometryEditor.tsx
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 import { Observer } from 'mobx-react-lite';
-import { action } from 'mobx';
+import { action, autorun } from 'mobx';
 import { forwardRef, useContext, useMemo } from 'react';
 import type { ReactNode, Ref } from 'react';
 import { StyleSheet } from 'react-native';
@@ -107,9 +107,7 @@ function GeometryEditorComponent(
   const setCustomUIProperty = action('set_custom_ui', () => {
     return store.setCustomUI(isCustomUI);
   });
-  if (store.controls.isCustomUI !== isCustomUI) {
-    setCustomUIProperty();
-  }
+  setCustomUIProperty();
 
   /**
    * A touch callback for the map that will add a new point

--- a/src/component/geometry/GeometryIO.tsx
+++ b/src/component/geometry/GeometryIO.tsx
@@ -6,6 +6,56 @@ import { StoreContext } from '../../state/StoreContext';
 import { exportGeometry, importGeometry } from '../../util/geometry/io';
 import type { GeometryImportError } from '../../util/geometry/io';
 import type { EditableGeometry } from '../../type/geometry';
+import {
+  useOnPressControl,
+  useOnPressEditControl,
+} from '../ui/control/modeControls';
+import {
+  useOnPressCancelControl,
+  useOnPressDeleteControl,
+  useOnPressFinishControl,
+  useOnPressRedoControl,
+  useOnPressUndoControl,
+} from '../ui/control/actionControls';
+
+/**
+ * Possible geometry editing modes
+ */
+export enum InteractionMode {
+  /**
+   * Reposition point geometry
+   */
+  DragPoint = 'DRAGPOINT',
+  /**
+   * Draw new point features
+   */
+  DrawPoint = 'DRAWPOINT',
+  /**
+   * Draw a new polygon
+   */
+  DrawPolygon = 'DRAWPOLYGON',
+  /**
+   * Draw a new polyline (line string)
+   */
+  DrawPolyline = 'DRAWPOLYLINE',
+  /**
+   * Edit metadata associated with a shape
+   */
+  EditMetadata = 'EDITMETADATA',
+  /**
+   * Edit compound shape vertices
+   */
+  EditVertices = 'EDITVERTICES',
+  /**
+   * Add shapes to the set of shapes selected for editing
+   */
+  SelectMultiple = 'SELECTMULTIPLE',
+  /**
+   * Select a shape to view its metadata or set it as
+   * the active shape for future editing
+   */
+  SelectSingle = 'SELECTSINGLE',
+}
 
 /**
  * Options controlling geometry import
@@ -88,6 +138,17 @@ export interface GeometryIORef {
    *         managed by this library.
    */
   export: () => Promise<FeatureCollection<EditableGeometry>>;
+  drawPolygon: () => void;
+  drawPoint: () => void;
+  drawPolyline: () => void;
+  edit: () => void;
+  selectSingleShape: () => void;
+  selectMultipleShapes: () => void;
+  undo: () => void;
+  redo: () => void;
+  cancel: () => void;
+  deleteShape: () => void;
+  confirm: () => void;
 }
 
 /**
@@ -103,14 +164,50 @@ function GeometryIOComponent(
 ) {
   const store = useContext(StoreContext);
 
+  const drawPoint = useOnPressControl(InteractionMode.DrawPoint);
+  const drawPolygon = useOnPressControl(InteractionMode.DrawPolygon);
+  const drawPolyline = useOnPressControl(InteractionMode.DrawPolyline);
+  const edit = useOnPressEditControl();
+  const selectSingleShape = useOnPressControl(InteractionMode.SelectSingle);
+  const selectMultipleShapes = useOnPressControl(InteractionMode.SelectSingle);
+  const undo = useOnPressUndoControl();
+  const redo = useOnPressRedoControl();
+  const cancel = useOnPressCancelControl();
+  const deleteShape = useOnPressDeleteControl();
+  const confirm = useOnPressFinishControl();
+
   useImperativeHandle(
     ref,
     (): GeometryIORef => ({
       import: (features: FeatureCollection, options: GeometryImportOptions) =>
         importGeometry(store, features, options),
       export: () => exportGeometry(store),
+      drawPoint,
+      drawPolygon,
+      drawPolyline,
+      edit,
+      selectSingleShape,
+      selectMultipleShapes,
+      undo,
+      redo,
+      cancel,
+      deleteShape,
+      confirm,
     }),
-    [store]
+    [
+      store,
+      drawPoint,
+      drawPolygon,
+      drawPolyline,
+      edit,
+      selectSingleShape,
+      selectMultipleShapes,
+      undo,
+      redo,
+      cancel,
+      deleteShape,
+      confirm,
+    ]
   );
   /**
    * This component has nothing meaningful to render, and is just used to integrate

--- a/src/component/geometry/GeometryIO.tsx
+++ b/src/component/geometry/GeometryIO.tsx
@@ -141,17 +141,53 @@ export interface GeometryIORef {
    *         managed by this library.
    */
   export: () => Promise<FeatureCollection<EditableGeometry>>;
+  /**
+   * A function for setting the Geometry Editor into draw polygon mode
+   */
   drawPolygon: () => void;
+  /**
+   * A function for setting the Geometry Editor into draw point mode
+   */
   drawPoint: () => void;
+  /**
+   * A function for setting the Geometry Editor into draw polyline mode
+   */
   drawPolyline: () => void;
+  /**
+   * A function for setting the Geometry Editor to edit the selected shape
+   */
   edit: () => void;
+  /**
+   * A function for setting the Geometry Editor into select single shape mode
+   */
   selectSingleShape: () => void;
+  /**
+   * A function for setting the Geometry Editor into select multiple shapes mode
+   */
   selectMultipleShapes: () => void;
+  /**
+   * A function for undoing the last action of the Geometry Editor
+   */
   undo: () => void;
+  /**
+   * A function for redoing the last action of the Geometry Editor
+   */
   redo: () => void;
+  /**
+   * A function for canceling the last action of the Geometry Editor
+   */
   cancel: () => void;
-  deleteShape: () => void;
+  /**
+   * A function for deleting a shape or point the currently selected shape of the Geometry Editor
+   */
+  deleteShapeOrPoint: () => void;
+  /**
+   * A function for confirming the last action of the Geometry Editor
+   */
   confirm: () => void;
+  /**
+   * A function for selecting the top shape in the Geometry Editor without having to tap on it
+   */
   selectTopShape: () => void;
 }
 
@@ -200,7 +236,7 @@ function GeometryIOComponent(
   const undo = useOnPressUndoControl(controls);
   const redo = useOnPressRedoControl(controls);
   const cancel = useOnPressCancelControl(controls);
-  const deleteShape = useOnPressDeleteControl(controls);
+  const deleteShapeOrPoint = useOnPressDeleteControl(controls);
   const confirm = useOnPressFinishControl(controls);
 
   useImperativeHandle(
@@ -220,7 +256,7 @@ function GeometryIOComponent(
       undo,
       redo,
       cancel,
-      deleteShape,
+      deleteShapeOrPoint,
       confirm,
       selectTopShape,
     }),
@@ -235,7 +271,7 @@ function GeometryIOComponent(
       undo,
       redo,
       cancel,
-      deleteShape,
+      deleteShapeOrPoint,
       confirm,
       selectTopShape,
     ]

--- a/src/component/geometry/GeometryIO.tsx
+++ b/src/component/geometry/GeometryIO.tsx
@@ -19,7 +19,6 @@ import {
 } from '../ui/control/actionControls';
 import { autorun } from 'mobx';
 import { ControlsModel } from 'src/state/ControlsModel';
-import { FeatureListModel } from 'src/state/FeatureListModel';
 
 /**
  * Possible geometry editing modes
@@ -173,7 +172,10 @@ function GeometryIOComponent(
   const store = useContext(StoreContext);
 
   let controls: ControlsModel | null = null;
-  let features: FeatureListModel | null = null;
+  let canUndo: boolean = false;
+  let canRedo: boolean = false;
+  let cannotUndoAndRedo: boolean = true;
+  let hasCompleteNewFeature: boolean = false;
   /**
    * We need to use a MobX observable in a reactive context,
    * which is provided by `autorun`
@@ -184,7 +186,10 @@ function GeometryIOComponent(
    */
   const disposer = autorun(() => {
     controls = store.controls;
-    features = store.features;
+    canUndo = store.features.canRedo;
+    canRedo = store.features.canRedo;
+    cannotUndoAndRedo = store.features.canRedo;
+    hasCompleteNewFeature = store.features.canRedo;
   });
   disposer();
 
@@ -228,10 +233,10 @@ function GeometryIOComponent(
       cancel,
       deleteShape,
       confirm,
-      canRedo: features?.canRedo,
-      canUndo: features?.canUndo,
-      cannotUndoAndRedo: features?.cannotUndoAndRedo,
-      hasCompleteNewFeature: features?.hasCompleteNewFeature,
+      canRedo,
+      canUndo,
+      cannotUndoAndRedo,
+      hasCompleteNewFeature,
       canDelete: controls?.canDelete,
     }),
     [
@@ -247,7 +252,10 @@ function GeometryIOComponent(
       cancel,
       deleteShape,
       confirm,
-      features,
+      canUndo,
+      canRedo,
+      cannotUndoAndRedo,
+      hasCompleteNewFeature,
       controls,
     ]
   );

--- a/src/component/geometry/GeometryIO.tsx
+++ b/src/component/geometry/GeometryIO.tsx
@@ -9,6 +9,7 @@ import type { EditableGeometry } from '../../type/geometry';
 import {
   useOnPressControl,
   useOnPressEditControl,
+  useSelectTopShapeControl,
 } from '../ui/control/modeControls';
 import {
   useOnPressCancelControl,
@@ -151,6 +152,7 @@ export interface GeometryIORef {
   cancel: () => void;
   deleteShape: () => void;
   confirm: () => void;
+  selectTopShape: () => void;
 }
 
 /**
@@ -194,6 +196,7 @@ function GeometryIOComponent(
     controls,
     InteractionMode.SelectSingle
   );
+  const selectTopShape = useSelectTopShapeControl(controls);
   const undo = useOnPressUndoControl(controls);
   const redo = useOnPressRedoControl(controls);
   const cancel = useOnPressCancelControl(controls);
@@ -219,6 +222,7 @@ function GeometryIOComponent(
       cancel,
       deleteShape,
       confirm,
+      selectTopShape,
     }),
     [
       store,
@@ -233,6 +237,7 @@ function GeometryIOComponent(
       cancel,
       deleteShape,
       confirm,
+      selectTopShape,
     ]
   );
   /**

--- a/src/component/geometry/GeometryIO.tsx
+++ b/src/component/geometry/GeometryIO.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useContext, useImperativeHandle, useState } from 'react';
+import { forwardRef, useContext, useImperativeHandle } from 'react';
 import type { ReactNode, Ref } from 'react';
 import type { FeatureCollection } from 'geojson';
 
@@ -151,11 +151,6 @@ export interface GeometryIORef {
   cancel: () => void;
   deleteShape: () => void;
   confirm: () => void;
-  canUndo: boolean | undefined;
-  canRedo: boolean | undefined;
-  cannotUndoAndRedo: boolean | undefined;
-  hasCompleteNewFeature: boolean | undefined;
-  canDelete: boolean | undefined;
 }
 
 /**
@@ -169,13 +164,7 @@ function GeometryIOComponent(
   { children }: { readonly children?: ReactNode },
   ref: Ref<GeometryIORef>
 ) {
-  const [canUndo, setCanUndo] = useState(false);
-  const [canRedo, setCanRedo] = useState(false);
-  const [cannotUndoAndRedo, setCannotUndoAndRedo] = useState(true);
-  const [hasCompleteNewFeature, setHasCompleteNewFeature] = useState(false);
-  const [canDelete, setCanDelete] = useState<boolean | undefined>(false);
   const store = useContext(StoreContext);
-
   let controls: ControlsModel | null = null;
   /**
    * We need to use a MobX observable in a reactive context,
@@ -187,27 +176,8 @@ function GeometryIOComponent(
    */
   const dispose = autorun(() => {
     controls = store.controls;
-    if (store.features.canUndo !== canUndo) {
-      setCanUndo(store.features.canUndo);
-      dispose();
-    }
-    if (store.features.canRedo !== canRedo) {
-      setCanRedo(store.features.canRedo);
-      dispose();
-    }
-    if (store.features.cannotUndoAndRedo !== cannotUndoAndRedo) {
-      setCannotUndoAndRedo(store.features.cannotUndoAndRedo);
-      dispose();
-    }
-    if (store.features.hasCompleteNewFeature !== hasCompleteNewFeature) {
-      setHasCompleteNewFeature(store.features.hasCompleteNewFeature);
-      dispose();
-    }
-    if (store.controls.canDelete !== canDelete) {
-      setCanDelete(store.controls.canDelete);
-      dispose();
-    }
   });
+  dispose();
 
   const drawPoint = useOnPressControl(controls, InteractionMode.DrawPoint);
   const drawPolygon = useOnPressControl(controls, InteractionMode.DrawPolygon);
@@ -249,11 +219,6 @@ function GeometryIOComponent(
       cancel,
       deleteShape,
       confirm,
-      canRedo,
-      canUndo,
-      cannotUndoAndRedo,
-      hasCompleteNewFeature,
-      canDelete,
     }),
     [
       store,
@@ -268,11 +233,6 @@ function GeometryIOComponent(
       cancel,
       deleteShape,
       confirm,
-      canUndo,
-      canRedo,
-      cannotUndoAndRedo,
-      hasCompleteNewFeature,
-      canDelete,
     ]
   );
   /**

--- a/src/component/geometry/GeometryIO.tsx
+++ b/src/component/geometry/GeometryIO.tsx
@@ -176,6 +176,7 @@ function GeometryIOComponent(
   let canRedo: boolean = false;
   let cannotUndoAndRedo: boolean = true;
   let hasCompleteNewFeature: boolean = false;
+  let canDelete: boolean | undefined = false;
   /**
    * We need to use a MobX observable in a reactive context,
    * which is provided by `autorun`
@@ -190,6 +191,7 @@ function GeometryIOComponent(
     canRedo = store.features.canRedo;
     cannotUndoAndRedo = store.features.canRedo;
     hasCompleteNewFeature = store.features.canRedo;
+    canDelete = store.controls.canDelete;
   });
   disposer();
 
@@ -237,7 +239,7 @@ function GeometryIOComponent(
       canUndo,
       cannotUndoAndRedo,
       hasCompleteNewFeature,
-      canDelete: controls?.canDelete,
+      canDelete,
     }),
     [
       store,
@@ -256,7 +258,7 @@ function GeometryIOComponent(
       canRedo,
       cannotUndoAndRedo,
       hasCompleteNewFeature,
-      controls,
+      canDelete,
     ]
   );
   /**

--- a/src/component/geometry/GeometryIO.tsx
+++ b/src/component/geometry/GeometryIO.tsx
@@ -17,6 +17,8 @@ import {
   useOnPressRedoControl,
   useOnPressUndoControl,
 } from '../ui/control/actionControls';
+import { autorun } from 'mobx';
+import { ControlsModel } from 'src/state/ControlsModel';
 
 /**
  * Possible geometry editing modes
@@ -164,17 +166,37 @@ function GeometryIOComponent(
 ) {
   const store = useContext(StoreContext);
 
-  const drawPoint = useOnPressControl(InteractionMode.DrawPoint);
-  const drawPolygon = useOnPressControl(InteractionMode.DrawPolygon);
-  const drawPolyline = useOnPressControl(InteractionMode.DrawPolyline);
-  const edit = useOnPressEditControl();
-  const selectSingleShape = useOnPressControl(InteractionMode.SelectSingle);
-  const selectMultipleShapes = useOnPressControl(InteractionMode.SelectSingle);
-  const undo = useOnPressUndoControl();
-  const redo = useOnPressRedoControl();
-  const cancel = useOnPressCancelControl();
-  const deleteShape = useOnPressDeleteControl();
-  const confirm = useOnPressFinishControl();
+  let control: ControlsModel | null = null;
+  /**
+   * We need to use a MobX observable in a reactive context,
+   * which is provided by `autorun`
+   * (https://mobx.js.org/reactions.html).
+   *
+   * Since we don't need the function to run whenever the observable changes
+   * in the future, we dispose of the reaction afterwards.
+   */
+  const disposer = autorun(() => {
+    control = store.controls;
+  });
+  disposer();
+
+  const drawPoint = useOnPressControl(control, InteractionMode.DrawPoint);
+  const drawPolygon = useOnPressControl(control, InteractionMode.DrawPolygon);
+  const drawPolyline = useOnPressControl(control, InteractionMode.DrawPolyline);
+  const edit = useOnPressEditControl(control);
+  const selectSingleShape = useOnPressControl(
+    control,
+    InteractionMode.SelectSingle
+  );
+  const selectMultipleShapes = useOnPressControl(
+    control,
+    InteractionMode.SelectSingle
+  );
+  const undo = useOnPressUndoControl(control);
+  const redo = useOnPressRedoControl(control);
+  const cancel = useOnPressCancelControl(control);
+  const deleteShape = useOnPressDeleteControl(control);
+  const confirm = useOnPressFinishControl(control);
 
   useImperativeHandle(
     ref,

--- a/src/component/ui/control/actionControls.tsx
+++ b/src/component/ui/control/actionControls.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
 import { observer } from 'mobx-react-lite';
 import { action } from 'mobx';
 
@@ -6,22 +6,53 @@ import { ActionButton } from '../../util/ActionButton';
 import { StoreContext } from '../../../state/StoreContext';
 import { InteractionMode } from '../../../state/ControlsModel';
 
+export function useOnPressRedoControl() {
+  const { controls } = useContext(StoreContext);
+  return action('redo_control_press', () => {
+    controls.redo();
+  });
+}
+
+export function useOnPressUndoControl() {
+  const { controls } = useContext(StoreContext);
+  return action('undo_control_press', () => {
+    controls.undo();
+  });
+}
+
+export function useOnPressDeleteControl() {
+  const { controls } = useContext(StoreContext);
+  return action('delete_control_press', () => {
+    controls.delete();
+  });
+}
+
+export function useOnPressFinishControl() {
+  const { controls } = useContext(StoreContext);
+  return action('finish_control_press', () => {
+    controls.confirm();
+  });
+}
+
+export function useOnPressCancelControl() {
+  const { controls } = useContext(StoreContext);
+  return action('rollback_control_press', () => {
+    controls.cancel();
+  });
+}
+
 /**
  * A component that renders a redo control
  */
 function _RedoControl() {
-  const { controls, features } = useContext(StoreContext);
-  // Button press callback
-  const onPress = useMemo(
-    () =>
-      action('redo_control_press', () => {
-        controls.redo();
-      }),
-    [controls]
-  );
+  const { features } = useContext(StoreContext);
 
   return (
-    <ActionButton icon="redo" disabled={!features.canRedo} onPress={onPress} />
+    <ActionButton
+      icon="redo"
+      disabled={!features.canRedo}
+      onPress={useOnPressRedoControl}
+    />
   );
 }
 
@@ -34,18 +65,14 @@ export const RedoControl = observer(_RedoControl);
  * A component that renders an undo control
  */
 function _UndoControl() {
-  const { controls, features } = useContext(StoreContext);
-  // Button press callback
-  const onPress = useMemo(
-    () =>
-      action('undo_control_press', () => {
-        controls.undo();
-      }),
-    [controls]
-  );
+  const { features } = useContext(StoreContext);
 
   return (
-    <ActionButton icon="undo" disabled={!features.canUndo} onPress={onPress} />
+    <ActionButton
+      icon="undo"
+      disabled={!features.canUndo}
+      onPress={useOnPressUndoControl}
+    />
   );
 }
 
@@ -59,14 +86,6 @@ export const UndoControl = observer(_UndoControl);
  */
 function _DeleteControl() {
   const { controls } = useContext(StoreContext);
-  // Button press callback
-  const onPress = useMemo(
-    () =>
-      action('delete_control_press', () => {
-        controls.delete();
-      }),
-    [controls]
-  );
 
   const enabled = controls.canDelete;
 
@@ -76,7 +95,13 @@ function _DeleteControl() {
     icon = 'delete-off-outline';
   }
 
-  return <ActionButton icon={icon} disabled={!enabled} onPress={onPress} />;
+  return (
+    <ActionButton
+      icon={icon}
+      disabled={!enabled}
+      onPress={useOnPressDeleteControl}
+    />
+  );
 }
 
 /**
@@ -90,14 +115,6 @@ export const DeleteControl = observer(_DeleteControl);
  */
 function _FinishControl() {
   const { controls, features } = useContext(StoreContext);
-  // Button press callback
-  const onPress = useMemo(
-    () =>
-      action('finish_control_press', () => {
-        controls.confirm();
-      }),
-    [controls]
-  );
 
   /**
    * Disable when there are no changes to save or discard
@@ -121,7 +138,13 @@ function _FinishControl() {
       break;
   }
 
-  return <ActionButton icon="check" disabled={disabled} onPress={onPress} />;
+  return (
+    <ActionButton
+      icon="check"
+      disabled={disabled}
+      onPress={useOnPressFinishControl}
+    />
+  );
 }
 
 /**
@@ -135,22 +158,18 @@ export const FinishControl = observer(_FinishControl);
  * history as well.
  */
 function _RollbackControl() {
-  const { controls } = useContext(StoreContext);
-  // Button press callback
-  const onPress = useMemo(
-    () =>
-      action('rollback_control_press', () => {
-        controls.cancel();
-      }),
-    [controls]
-  );
-
   /**
    * The button is always enabled because it should always be possible for the user
    * to escape the current editing context. The rest of the user interface is responsible
    * for rendering this button only when it makes sense.
    */
-  return <ActionButton icon="cancel" disabled={false} onPress={onPress} />;
+  return (
+    <ActionButton
+      icon="cancel"
+      disabled={false}
+      onPress={useOnPressCancelControl}
+    />
+  );
 }
 
 /**

--- a/src/component/ui/control/actionControls.tsx
+++ b/src/component/ui/control/actionControls.tsx
@@ -4,40 +4,35 @@ import { action } from 'mobx';
 
 import { ActionButton } from '../../util/ActionButton';
 import { StoreContext } from '../../../state/StoreContext';
-import { InteractionMode } from '../../../state/ControlsModel';
+import { ControlsModel, InteractionMode } from '../../../state/ControlsModel';
 
-export function useOnPressRedoControl() {
-  const { controls } = useContext(StoreContext);
+export function useOnPressRedoControl(controls: ControlsModel | null) {
   return action('redo_control_press', () => {
-    controls.redo();
+    controls?.redo();
   });
 }
 
-export function useOnPressUndoControl() {
-  const { controls } = useContext(StoreContext);
+export function useOnPressUndoControl(controls: ControlsModel | null) {
   return action('undo_control_press', () => {
-    controls.undo();
+    controls?.undo();
   });
 }
 
-export function useOnPressDeleteControl() {
-  const { controls } = useContext(StoreContext);
+export function useOnPressDeleteControl(controls: ControlsModel | null) {
   return action('delete_control_press', () => {
-    controls.delete();
+    controls?.delete();
   });
 }
 
-export function useOnPressFinishControl() {
-  const { controls } = useContext(StoreContext);
+export function useOnPressFinishControl(controls: ControlsModel | null) {
   return action('finish_control_press', () => {
-    controls.confirm();
+    controls?.confirm();
   });
 }
 
-export function useOnPressCancelControl() {
-  const { controls } = useContext(StoreContext);
+export function useOnPressCancelControl(controls: ControlsModel | null) {
   return action('rollback_control_press', () => {
-    controls.cancel();
+    controls?.cancel();
   });
 }
 
@@ -45,13 +40,13 @@ export function useOnPressCancelControl() {
  * A component that renders a redo control
  */
 function _RedoControl() {
-  const { features } = useContext(StoreContext);
+  const { controls, features } = useContext(StoreContext);
 
   return (
     <ActionButton
       icon="redo"
       disabled={!features.canRedo}
-      onPress={useOnPressRedoControl}
+      onPress={useOnPressRedoControl(controls)}
     />
   );
 }
@@ -65,13 +60,13 @@ export const RedoControl = observer(_RedoControl);
  * A component that renders an undo control
  */
 function _UndoControl() {
-  const { features } = useContext(StoreContext);
+  const { controls, features } = useContext(StoreContext);
 
   return (
     <ActionButton
       icon="undo"
       disabled={!features.canUndo}
-      onPress={useOnPressUndoControl}
+      onPress={useOnPressUndoControl(controls)}
     />
   );
 }
@@ -99,7 +94,7 @@ function _DeleteControl() {
     <ActionButton
       icon={icon}
       disabled={!enabled}
-      onPress={useOnPressDeleteControl}
+      onPress={useOnPressDeleteControl(controls)}
     />
   );
 }
@@ -142,7 +137,7 @@ function _FinishControl() {
     <ActionButton
       icon="check"
       disabled={disabled}
-      onPress={useOnPressFinishControl}
+      onPress={useOnPressFinishControl(controls)}
     />
   );
 }
@@ -158,6 +153,7 @@ export const FinishControl = observer(_FinishControl);
  * history as well.
  */
 function _RollbackControl() {
+  const { controls } = useContext(StoreContext);
   /**
    * The button is always enabled because it should always be possible for the user
    * to escape the current editing context. The rest of the user interface is responsible
@@ -167,7 +163,7 @@ function _RollbackControl() {
     <ActionButton
       icon="cancel"
       disabled={false}
-      onPress={useOnPressCancelControl}
+      onPress={useOnPressCancelControl(controls)}
     />
   );
 }

--- a/src/component/ui/control/actionControls.tsx
+++ b/src/component/ui/control/actionControls.tsx
@@ -6,30 +6,55 @@ import { ActionButton } from '../../util/ActionButton';
 import { StoreContext } from '../../../state/StoreContext';
 import { ControlsModel, InteractionMode } from '../../../state/ControlsModel';
 
+/**
+ * A function that calls a redo action
+ * @param controls
+ * @returns the function to call the redo action
+ */
 export function useOnPressRedoControl(controls: ControlsModel | null) {
   return action('redo_control_press', () => {
     controls?.redo();
   });
 }
 
+/**
+ * A function that calls an undo action
+ * @param controls
+ * @returns the function to call the undo action
+ */
 export function useOnPressUndoControl(controls: ControlsModel | null) {
   return action('undo_control_press', () => {
     controls?.undo();
   });
 }
 
+/**
+ * A function that calls a delete action
+ * @param controls
+ * @returns the function to call the delete action
+ */
 export function useOnPressDeleteControl(controls: ControlsModel | null) {
   return action('delete_control_press', () => {
     controls?.delete();
   });
 }
 
+/**
+ * A function that calls a confirm action
+ * @param controls
+ * @returns the function to call the confirm action
+ */
 export function useOnPressFinishControl(controls: ControlsModel | null) {
   return action('finish_control_press', () => {
     controls?.confirm();
   });
 }
 
+/**
+ * A function that calls a cancel action
+ * @param controls
+ * @returns the function to call the cancel action
+ */
 export function useOnPressCancelControl(controls: ControlsModel | null) {
   return action('rollback_control_press', () => {
     controls?.cancel();

--- a/src/component/ui/control/modeControls.tsx
+++ b/src/component/ui/control/modeControls.tsx
@@ -3,21 +3,20 @@ import { action } from 'mobx';
 import { useContext, useMemo } from 'react';
 import { ToggleButton } from 'react-native-paper';
 
-import { InteractionMode } from '../../../state/ControlsModel';
+import { ControlsModel, InteractionMode } from '../../../state/ControlsModel';
 import { StoreContext } from '../../../state/StoreContext';
 
-export function useOnPressControl(mode: InteractionMode) {
-  const { controls } = useContext(StoreContext);
+export function useOnPressControl(
+  controls: ControlsModel | null,
+  mode: InteractionMode
+) {
   return action('mode_control_press', () => {
-    controls.toggleMode(mode);
+    controls?.toggleMode(mode);
   });
 }
-
-export function useOnPressEditControl() {
-  const { controls } = useContext(StoreContext);
-
+export function useOnPressEditControl(controls: ControlsModel | null) {
   return action('edit_control_press', () => {
-    controls.toggleMode(InteractionMode.EditVertices);
+    controls?.toggleMode(InteractionMode.EditVertices);
   });
 }
 
@@ -39,7 +38,7 @@ export function makeModeControl(mode: InteractionMode, icon: string) {
     return (
       <ToggleButton
         icon={icon}
-        onPress={useOnPressControl(mode)}
+        onPress={useOnPressControl(controls, mode)}
         value={mode}
         status={status}
       />

--- a/src/component/ui/control/modeControls.tsx
+++ b/src/component/ui/control/modeControls.tsx
@@ -6,6 +6,12 @@ import { ToggleButton } from 'react-native-paper';
 import { ControlsModel, InteractionMode } from '../../../state/ControlsModel';
 import { StoreContext } from '../../../state/StoreContext';
 
+/**
+ * A function that toggles the current mode of the geometry editor
+ * @param controls
+ * @param mode: the mode to swap the geometry editor into
+ * @returns the function to call the mode toggle action
+ */
 export function useOnPressControl(
   controls: ControlsModel | null,
   mode: InteractionMode
@@ -14,12 +20,22 @@ export function useOnPressControl(
     controls?.toggleMode(mode);
   });
 }
+
+/**
+ * A function that calls an edit
+ * @param controls
+ * @returns the function to call the edit action
+ */
 export function useOnPressEditControl(controls: ControlsModel | null) {
   return action('edit_control_press', () => {
     controls?.toggleMode(InteractionMode.EditVertices);
   });
 }
-
+/**
+ * A function that calls a select top shape action
+ * @param controls
+ * @returns the function to call the select top shape action
+ */
 export function useSelectTopShapeControl(controls: ControlsModel | null) {
   return action('mode_control_select_top_shape', () => {
     controls?.selectTopShape();

--- a/src/component/ui/control/modeControls.tsx
+++ b/src/component/ui/control/modeControls.tsx
@@ -20,6 +20,12 @@ export function useOnPressEditControl(controls: ControlsModel | null) {
   });
 }
 
+export function useSelectTopShapeControl(controls: ControlsModel | null) {
+  return action('mode_control_select_top_shape', () => {
+    controls?.selectTopShape();
+  });
+}
+
 /**
  * Create a toggle button that enables and disables an editing mode
  * @param mode The editing mode

--- a/src/component/ui/control/modeControls.tsx
+++ b/src/component/ui/control/modeControls.tsx
@@ -113,7 +113,7 @@ function _ShapeEditControl() {
 
   // Button enabled/disabled state
   let enabled = false;
-  // Any editing mode that pressing the button will activate  let nextMode:
+  // Any editing mode that pressing the button will activate
   let nextMode:
     | null
     | InteractionMode.DragPoint

--- a/src/component/ui/control/modeControls.tsx
+++ b/src/component/ui/control/modeControls.tsx
@@ -6,23 +6,31 @@ import { ToggleButton } from 'react-native-paper';
 import { InteractionMode } from '../../../state/ControlsModel';
 import { StoreContext } from '../../../state/StoreContext';
 
+export function useOnPressControl(mode: InteractionMode) {
+  const { controls } = useContext(StoreContext);
+  return action('mode_control_press', () => {
+    controls.toggleMode(mode);
+  });
+}
+
+export function useOnPressEditControl() {
+  const { controls } = useContext(StoreContext);
+
+  return action('edit_control_press', () => {
+    controls.toggleMode(InteractionMode.EditVertices);
+  });
+}
+
 /**
  * Create a toggle button that enables and disables an editing mode
  * @param mode The editing mode
  * @param icon The icon to apply to the toggle button
  * @return A React component for rendering an editing mode toggle button
  */
-function makeModeControl(mode: InteractionMode, icon: string) {
+export function makeModeControl(mode: InteractionMode, icon: string) {
   return observer(() => {
     const { controls } = useContext(StoreContext);
 
-    const onPress = useMemo(
-      () =>
-        action('mode_control_press', () => {
-          controls.toggleMode(mode);
-        }),
-      [controls]
-    );
     let status: 'unchecked' | 'checked' = 'unchecked';
     if (controls.mode === mode) {
       status = 'checked';
@@ -31,7 +39,7 @@ function makeModeControl(mode: InteractionMode, icon: string) {
     return (
       <ToggleButton
         icon={icon}
-        onPress={onPress}
+        onPress={useOnPressControl(mode)}
         value={mode}
         status={status}
       />
@@ -84,7 +92,7 @@ function _ShapeEditControl() {
 
   // Button enabled/disabled state
   let enabled = false;
-  // Any editing mode that pressing the button will activate
+  // Any editing mode that pressing the button will activate  let nextMode:
   let nextMode:
     | null
     | InteractionMode.DragPoint

--- a/src/state/ControlsModel.ts
+++ b/src/state/ControlsModel.ts
@@ -896,7 +896,9 @@ export class ControlsModel extends Model({
       case InteractionMode.SelectMultiple:
       case InteractionMode.SelectSingle:
         features?.deleteSelected();
-        features?.clearHistory();
+        if (this.isCustomUI) {
+          features?.clearHistory();
+        }
         break;
       case InteractionMode.DragPoint:
       case InteractionMode.DrawPoint:

--- a/src/state/ControlsModel.ts
+++ b/src/state/ControlsModel.ts
@@ -687,9 +687,11 @@ export class ControlsModel extends Model({
         case InteractionMode.DrawPolygon:
         case InteractionMode.DrawPolyline:
           if (this.isCustomUI) {
-            features?.discardNewFeatures();
-            this.clearMetadata();
-            this.isPageOpen = false;
+            features?.rollbackEditingSession();
+            features?.clearHistory();
+            this.clearMetadata(); // Clear any metadata entered up to now
+            this.confirmation = null; // Otherwise there will be a warning about changing the editing mode while there is a confirmation request open
+            this.setDefaultMode(); // Exit shape drawing mode
             break;
           } else if (this.isPageOpen) {
             // User goes back to drawing from metadata entry

--- a/src/state/ControlsModel.ts
+++ b/src/state/ControlsModel.ts
@@ -1292,4 +1292,47 @@ export class ControlsModel extends Model({
         return true;
     }
   }
+
+  /**
+   * Select the top geometry that has been imported to the Geometry Editing Library
+   * without having to tap on it
+   */
+  @modelAction
+  selectTopShape() {
+    const features = featureListContext.get(this);
+    console.log(features?.features[0].$modelId);
+    switch (this.mode) {
+      case InteractionMode.DragPoint:
+      case InteractionMode.EditVertices:
+      case InteractionMode.DrawPoint:
+      case InteractionMode.DrawPolygon:
+      case InteractionMode.DrawPolyline:
+      case InteractionMode.EditMetadata:
+        // Ignore
+        // We only want to select the shape if we are in select mode
+        break;
+      case InteractionMode.SelectMultiple:
+      case InteractionMode.SelectSingle:
+        //if there is a feature
+        if (features && features.features.length > 0) {
+          //get the id of the top feature
+          let id = features?.features[0].$modelId;
+          //select the top feature
+          if (this.mode === InteractionMode.SelectMultiple) {
+            features?.toggleSingleSelectFeature(id);
+          } else if (this.mode === InteractionMode.SelectSingle) {
+            features?.toggleSingleSelectFeature(id);
+          } else {
+            throw new Error(
+              `There is no branch for the current editing mode, ${this.mode}, for selecting features.`
+            );
+          }
+        } else {
+          throw new Error(
+            `There is not exactly one shape in the feature to select in selectOnlyShape.`
+          );
+        }
+        break;
+    }
+  }
 }

--- a/src/state/ControlsModel.ts
+++ b/src/state/ControlsModel.ts
@@ -579,9 +579,9 @@ export class ControlsModel extends Model({
       // This is a state change in the absence of a confirmation dialog
       switch (this.mode) {
         case InteractionMode.DrawPoint:
-          // Save the new point
+          this.saveMetadata();
           features?.confirmNewFeatures();
-          this.setDefaultMode();
+          this.isPageOpen = false;
           break;
         case InteractionMode.DrawPolygon:
         case InteractionMode.DrawPolyline:

--- a/src/state/ControlsModel.ts
+++ b/src/state/ControlsModel.ts
@@ -690,8 +690,6 @@ export class ControlsModel extends Model({
             features?.rollbackEditingSession();
             features?.clearHistory();
             this.clearMetadata(); // Clear any metadata entered up to now
-            this.confirmation = null; // Otherwise there will be a warning about changing the editing mode while there is a confirmation request open
-            this.setDefaultMode(); // Exit shape drawing mode
             break;
           } else if (this.isPageOpen) {
             // User goes back to drawing from metadata entry

--- a/src/state/ControlsModel.ts
+++ b/src/state/ControlsModel.ts
@@ -1300,7 +1300,6 @@ export class ControlsModel extends Model({
   @modelAction
   selectTopShape() {
     const features = featureListContext.get(this);
-    console.log(features?.features[0].$modelId);
     switch (this.mode) {
       case InteractionMode.DragPoint:
       case InteractionMode.EditVertices:

--- a/src/state/RootModel.ts
+++ b/src/state/RootModel.ts
@@ -48,7 +48,6 @@ export class RootModel extends Model({
   @modelAction
   setCustomUI(isCustomUI?: boolean) {
     if (isCustomUI) {
-      console.log('setting custom UI');
       this.controls.isCustomUI = isCustomUI;
     } else {
       this.controls.isCustomUI = false;

--- a/src/state/RootModel.ts
+++ b/src/state/RootModel.ts
@@ -41,6 +41,21 @@ export class RootModel extends Model({
   }
 
   /**
+   * Sets the value stating whether or not the geometry editor is using a custom UI or not
+   *
+   * @param isCustomUI whether or not the geometry editor is using a custom UI
+   */
+  @modelAction
+  setCustomUI(isCustomUI?: boolean) {
+    if (isCustomUI) {
+      console.log('setting custom UI');
+      this.controls.isCustomUI = isCustomUI;
+    } else {
+      this.controls.isCustomUI = false;
+    }
+  }
+
+  /**
    * Import features into the state stores
    * @param features The new features to store
    * @param options Options controlling the import operation


### PR DESCRIPTION
I'd like to merge my review branch into its feature branch.

This pull request is related to the following task IDs on ProofHub: [#14206](https://work.mojow.ai/bapplite/#app/todos/project-4202996375/list-263543515039/task-304094201136)

## Summary of changes

1. Expose functions to create custom UI that can control the Geometry Editor (confirm, undo, redo, delete, etc.)
2. Add props to `GeometryEditor` that allows you to pass a function to set values containing information about when the buttons should be displayed (canUndo, canRedo, canDelete, etc.)
3. Added `isCustomUI` flag to tell the `GeometryEditor` to use different logic when pressing buttons that will not trigger the default UI for setting metadata and popups

## Any tips to help running or testing the new changes

1. Follow the instructions in the `readme` to install and run the example app
2. Press `Toggle UI` button to toggle to the custom UI
3. You should see external buttons for controlling the Geometry Editor
4. If you tap on one of the `draw` buttons you should immediately be able to draw the shape on the map
5. If you tap `confirm` or `cancel` after drawing the action should be immediately taken as you have to provide an external confirmation
6. While you are drawing or editing a shape the `undo`, `redo`, and `delete` buttons should activate at the correct times
7. Press `Toggle UI` again and verify that the default example app still functions correctly

## Notes

Thanks for reviewing and helping the team to improve quality of their work with your feedback.
